### PR TITLE
Make timezone-series build with time >= 1.8 and NOT time < 1.8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3334,7 +3334,7 @@ package-flags:
         containers: false
 
     timezone-series:
-        time_1_6_and_1_7: true
+        time_1_6_and_1_7: false
         time_pre_1_6: false
 
     mintty:


### PR DESCRIPTION
**PLEASE READ BEFORE MERGING THIS PR !!**

Based on a notification I received (fpco/stackage#2678), this PR changes the `timezone-series` library to build with `time >= 1.8` and NOT build anymore with `time < 1.8`

I do not know enough about how dependencies work across various stackage versions to be able to say if that is really the right thing to do. If you have the power to merge this PR, you probably do know. So please either merge the PR, or tell me what to do if this is not the Right Thing. Thanks!